### PR TITLE
change redirect config path with auto data move

### DIFF
--- a/action.php
+++ b/action.php
@@ -14,7 +14,7 @@ require_once(DOKU_PLUGIN.'action.php');
 
 class action_plugin_redirect extends DokuWiki_Action_Plugin {
 
-    var $redirects;
+    protected $redirects; // redirection hash
 
     function __construct() {
         global $config_cascade;

--- a/action.php
+++ b/action.php
@@ -14,16 +14,10 @@ require_once(DOKU_PLUGIN.'action.php');
 
 class action_plugin_redirect extends DokuWiki_Action_Plugin {
 
-    protected $redirects; // redirection hash
+    protected $ConfFile;  // path/to/redirection config file
 
     public function __construct() {
-        global $config_cascade;
-        $config_cascade = array_merge( $config_cascade, array(
-            'redirects' => array(
-                'default' => array(DOKU_CONF.'redirect.conf'),
-                'local'   => array(DOKU_CONF.'redirect.local.conf'),
-            ),
-        ));
+        $this->ConfFile = DOKU_CONF.'redirect.conf';
     }
 
     /**
@@ -41,21 +35,18 @@ class action_plugin_redirect extends DokuWiki_Action_Plugin {
 
         if ($ACT != 'show') return;
 
-        $this->redirects = retrieveConfig('redirects','confToHash');
-        if($this->redirects[$ID]){
-            if (preg_match('/^https?:\/\//',$this->redirects[$ID])) {
-                send_redirect($this->redirects[$ID]);
+        $redirects = confToHash($this->ConfFile);
+        if ($redirects[$ID]) {
+            if (preg_match('/^https?:\/\//',$redirects[$ID])) {
+                send_redirect($redirects[$ID]);
             } else {
                 if ($this->getConf('showmsg')) {
                     msg(sprintf($this->getLang('redirected'),hsc($ID)));
                 }
-                $link = explode('#', $this->redirects[$ID], 2);
+                $link = explode('#', $redirects[$ID], 2);
                 send_redirect(wl($link[0] ,'',true) . '#' . rawurlencode($link[1]));
             }
             exit;
         }
     }
-
-
 }
-

--- a/action.php
+++ b/action.php
@@ -24,7 +24,6 @@ class action_plugin_redirect extends DokuWiki_Action_Plugin {
                 'local'   => array(DOKU_CONF.'redirect.local.conf'),
             ),
         ));
-        $this->redirects = retrieveConfig('redirects','confToHash');
     }
 
     /**
@@ -46,6 +45,7 @@ class action_plugin_redirect extends DokuWiki_Action_Plugin {
 
         if($ACT != 'show') return;
 
+        $this->redirects = retrieveConfig('redirects','confToHash');
         if($this->redirects[$ID]){
             if(preg_match('/^https?:\/\//',$this->redirects[$ID])){
                 send_redirect($this->redirects[$ID]);

--- a/action.php
+++ b/action.php
@@ -14,6 +14,19 @@ require_once(DOKU_PLUGIN.'action.php');
 
 class action_plugin_redirect extends DokuWiki_Action_Plugin {
 
+    var $redirects;
+
+    function __construct() {
+        global $config_cascade;
+        $config_cascade = array_merge( $config_cascade, array(
+            'redirects' => array(
+                'default' => array(DOKU_CONF.'redirect.conf'),
+                'local'   => array(DOKU_CONF.'redirect.local.conf'),
+            ),
+        ));
+        $this->redirects = retrieveConfig('redirects','confToHash');
+    }
+
     /**
      * register the eventhandlers
      */
@@ -29,20 +42,18 @@ class action_plugin_redirect extends DokuWiki_Action_Plugin {
      * handle event
      */
     function handle_start(&$event, $param){
-        global $ID;
-        global $ACT;
+        global $ID, $ACT;
 
         if($ACT != 'show') return;
 
-        $redirects = confToHash(dirname(__FILE__).'/redirect.conf');
-        if($redirects[$ID]){
-            if(preg_match('/^https?:\/\//',$redirects[$ID])){
-                send_redirect($redirects[$ID]);
+        if($this->redirects[$ID]){
+            if(preg_match('/^https?:\/\//',$this->redirects[$ID])){
+                send_redirect($this->redirects[$ID]);
             }else{
                 if($this->getConf('showmsg')){
                     msg(sprintf($this->getLang('redirected'),hsc($ID)));
                 }
-                $link = explode('#', $redirects[$ID], 2);
+                $link = explode('#', $this->redirects[$ID], 2);
                 send_redirect(wl($link[0] ,'',true) . '#' . rawurlencode($link[1]));
             }
             exit;

--- a/action.php
+++ b/action.php
@@ -16,7 +16,7 @@ class action_plugin_redirect extends DokuWiki_Action_Plugin {
 
     protected $redirects; // redirection hash
 
-    function __construct() {
+    public function __construct() {
         global $config_cascade;
         $config_cascade = array_merge( $config_cascade, array(
             'redirects' => array(
@@ -29,28 +29,24 @@ class action_plugin_redirect extends DokuWiki_Action_Plugin {
     /**
      * register the eventhandlers
      */
-    function register(&$controller){
-        $controller->register_hook('DOKUWIKI_STARTED',
-                                   'AFTER',
-                                   $this,
-                                   'handle_start',
-                                   array());
+    public function register(Doku_Event_Handler $controller) {
+        $controller->register_hook('DOKUWIKI_STARTED', 'AFTER', $this, 'handle_start', array());
     }
 
     /**
      * handle event
      */
-    function handle_start(&$event, $param){
+    public function handle_start(&$event, $param){
         global $ID, $ACT;
 
-        if($ACT != 'show') return;
+        if ($ACT != 'show') return;
 
         $this->redirects = retrieveConfig('redirects','confToHash');
         if($this->redirects[$ID]){
-            if(preg_match('/^https?:\/\//',$this->redirects[$ID])){
+            if (preg_match('/^https?:\/\//',$this->redirects[$ID])) {
                 send_redirect($this->redirects[$ID]);
-            }else{
-                if($this->getConf('showmsg')){
+            } else {
+                if ($this->getConf('showmsg')) {
                     msg(sprintf($this->getLang('redirected'),hsc($ID)));
                 }
                 $link = explode('#', $this->redirects[$ID], 2);

--- a/admin.php
+++ b/admin.php
@@ -18,18 +18,17 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
         $confPath = array(
             'legacy'     => dirname(__FILE__).'/redirect.conf', // to be deprecated
             'default'    => DOKU_CONF.'redirect.conf',
-            'local'      => DOKU_CONF.'redirect.local.conf',
         );
 
         // copy config entries from legacy to local
-        if (!file_exists($confPath['local']) && file_exists($confPath['legacy'])) {
+        if (!file_exists($confPath['default']) && file_exists($confPath['legacy'])) {
             $data = io_readFile($confPath['legacy']);
-            io_saveFile($confPath['local'], $data);
+            io_saveFile($confPath['default'], $data);
             unlink($confPath['legacy']); // remove legacy file
         }
 
         // set ConfFile
-        $this->ConfFile = $confPath['local'];
+        $this->ConfFile = $confPath['default'];
     }
 
     /**

--- a/admin.php
+++ b/admin.php
@@ -13,7 +13,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
 
     protected $ConfFile;  // path/to/redirection config file
 
-    function __construct() {
+    public function __construct() {
         // redirection config path options
         $confPath = array(
             'legacy'     => dirname(__FILE__).'/redirect.conf', // to be deprecated
@@ -35,31 +35,27 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
     /**
      * Access for managers allowed
      */
-    function forAdminOnly(){
-        return false;
-    }
+    public function forAdminOnly() { return false; }
 
     /**
      * return sort order for position in admin menu
      */
-    function getMenuSort() {
-        return 140;
-    }
+    public function getMenuSort() { return 140; }
 
     /**
      * return prompt for admin menu
      */
-    function getMenuText($language) {
+    public function getMenuText($language) {
         return $this->getLang('name');
     }
 
     /**
      * handle user request
      */
-    function handle() {
-        if($_POST['redirdata']){
-            if(!checkSecurityToken()) return;
-            if(io_saveFile($this->ConfFile, cleanText($_POST['redirdata']))){
+    public function handle() {
+        if ($_POST['redirdata']) {
+            if (!checkSecurityToken()) return;
+            if (io_saveFile($this->ConfFile, cleanText($_POST['redirdata']))) {
                 msg($this->getLang('saved'),1);
             }
         }
@@ -68,7 +64,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
     /**
      * output appropriate html
      */
-    function html() {
+    public function html() {
         global $lang;
         echo $this->locale_xhtml('intro');
         echo '<form action="" method="post" >';

--- a/admin.php
+++ b/admin.php
@@ -25,7 +25,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
         if (!file_exists($confPath['local']) && file_exists($confPath['legacy'])) {
             $data = io_readFile($confPath['legacy']);
             io_saveFile($confPath['local'], $data);
-            unlink(($confPath['legacy']); // remove legacy file
+            unlink($confPath['legacy']); // remove legacy file
         }
 
         // set ConfFile
@@ -58,6 +58,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
      */
     function handle() {
         if($_POST['redirdata']){
+            if(!checkSecurityToken()) return;
             if(io_saveFile($this->ConfFile, cleanText($_POST['redirdata']))){
                 msg($this->getLang('saved'),1);
             }
@@ -73,6 +74,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
         echo '<form action="" method="post" >';
         echo '<input type="hidden" name="do" value="admin" />';
         echo '<input type="hidden" name="page" value="redirect" />';
+        echo '<input type="hidden" name="sectok" value="'.getSecurityToken().'" />';
         echo '<textarea class="edit" rows="15" cols="80" style="height: 300px" name="redirdata">';
         echo formtext(io_readFile($this->ConfFile));
         echo '</textarea><br />';

--- a/admin.php
+++ b/admin.php
@@ -11,7 +11,7 @@ require_once(DOKU_PLUGIN.'admin.php');
  */
 class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
 
-    var $ConfFile;  // path/to/redirection config file
+    protected $ConfFile;  // path/to/redirection config file
 
     function __construct() {
         // redirection config path options

--- a/admin.php
+++ b/admin.php
@@ -25,7 +25,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
         if (!file_exists($confPath['local']) && file_exists($confPath['legacy'])) {
             $data = io_readFile($confPath['legacy']);
             io_saveFile($confPath['local'], $data);
-            io_saveFile($confPath['legacy'], ''); // blank legacy file
+            unlink(($confPath['legacy']); // remove legacy file
         }
 
         // set ConfFile

--- a/admin.php
+++ b/admin.php
@@ -11,6 +11,27 @@ require_once(DOKU_PLUGIN.'admin.php');
  */
 class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
 
+    var $ConfFile;  // path/to/redirection config file
+
+    function __construct() {
+        // redirection config path options
+        $confPath = array(
+            'legacy'     => dirname(__FILE__).'/redirect.conf', // to be deprecated
+            'default'    => DOKU_CONF.'redirect.conf',
+            'local'      => DOKU_CONF.'redirect.local.conf',
+        );
+
+        // copy config entries from legacy to local
+        if (!file_exists($confPath['local']) && file_exists($confPath['legacy'])) {
+            $data = io_readFile($confPath['legacy']);
+            io_saveFile($confPath['local'], $data);
+            io_saveFile($confPath['legacy'], ''); // blank legacy file
+        }
+
+        // set ConfFile
+        $this->ConfFile = $confPath['local'];
+    }
+
     /**
      * Access for managers allowed
      */
@@ -37,7 +58,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
      */
     function handle() {
         if($_POST['redirdata']){
-            if(io_saveFile(dirname(__FILE__).'/redirect.conf',cleanText($_POST['redirdata']))){
+            if(io_saveFile($this->ConfFile, cleanText($_POST['redirdata']))){
                 msg($this->getLang('saved'),1);
             }
         }
@@ -53,7 +74,7 @@ class admin_plugin_redirect extends DokuWiki_Admin_Plugin {
         echo '<input type="hidden" name="do" value="admin" />';
         echo '<input type="hidden" name="page" value="redirect" />';
         echo '<textarea class="edit" rows="15" cols="80" style="height: 300px" name="redirdata">';
-        echo formtext(io_readFile(dirname(__FILE__).'/redirect.conf'));
+        echo formtext(io_readFile($this->ConfFile));
         echo '</textarea><br />';
         echo '<input type="submit" value="'.$lang['btn_save'].'" class="button" />';
         echo '</form>';


### PR DESCRIPTION
This request intend to provide support for wiki farming, exactly change of conf file path 
so that each animal can hold own redirect hash table. Also resolve the issue #2.

The old hash data stored in the plugin directory (`redirect.conf`) will be copied to new file ''`redirect.local.conf`'' in DOKU_CONF directory, therefore no extra configuration required after the plugin update. This request is elaborated from #8

I propose to use `redirect.local.conf` for hash filename considering analogy with acronyms/entities etc.
