### PR TITLE
Issue #4 Wildcard redirect

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -62,6 +62,29 @@ class helper_plugin_redirect extends DokuWiki_Admin_Plugin {
      */
     public function getRedirectURL($id) {
         $redirects = confToHash(self::CONFIG_FILE);
+
+        /*
+        * Support for wildcard redirects
+        *
+        * Examples:
+        * myteam:*        contacts:mycompany:mydepartment:myteam:$1
+        * client:*        contacts:clients:clientname:$1
+        * server:*        it:system_dpt:resources:servers:$1
+        *
+        */
+         $newID = "";
+         foreach ( $redirects as $mask=>$target )
+              {
+               $regex_mask = '/^'.preg_replace( '/\*/', '(.*)', $mask ).'/';
+               if ( preg_match( $regex_mask, $id, $matches ) )
+               {
+                       $newID = preg_replace( $regex_mask, $target, $id );
+                       break;
+               }
+              }
+
+         $redirects[$id] = $newID;
+
         if(empty($redirects[$id])) return false;
 
         if(preg_match('/^https?:\/\//', $redirects[$id])) {


### PR DESCRIPTION
Since the refactoring to helper.php, the old suggestion for wildcard redirects works, if you place the code in the helper file.

https://github.com/splitbrain/dokuwiki-plugin-redirect/issues/4