### PR TITLE
Dummy implementation of an abstract method

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -77,4 +77,12 @@ class helper_plugin_redirect extends DokuWiki_Admin_Plugin {
 
         return $url;
     }
+
+    /**
+     * Dummy implementation of an abstract method
+     */
+    public function html()
+    {
+        return '';
+    }
 }


### PR DESCRIPTION
Missing html() causes a fatal error